### PR TITLE
fix: lock devenv to `devenvNixpkgs`

### DIFF
--- a/.github/workflows/normal.yaml
+++ b/.github/workflows/normal.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: "Build & Test: ${{ matrix.language }}"
         run: just ci just maintenance::test ${{ matrix.language }}
 
-  test-images:
+  test-image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,4 +35,4 @@ jobs:
           cachix_cache_name: "${{ secrets.CACHIX_CACHE_NAME }}"
           cachix_auth_token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: "Build & Test Images"
-        run: just ci just maintenance::test-images
+        run: just ci just maintenance::test-image

--- a/.github/workflows/normal.yaml
+++ b/.github/workflows/normal.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: "Build & Test: ${{ matrix.language }}"
         run: just ci just maintenance::test ${{ matrix.language }}
 
-  test-image:
+  test-images:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/normal.yaml
+++ b/.github/workflows/normal.yaml
@@ -10,7 +10,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  test-templates:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [generic, python, go, rust]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-nix
+        with:
+          cachix_cache_name: "${{ secrets.CACHIX_CACHE_NAME }}"
+          cachix_auth_token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: "Build & Test: ${{ matrix.language }}"
+        run: just ci just maintenance::test ${{ matrix.language }}
+
+  test-image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,5 +34,5 @@ jobs:
         with:
           cachix_cache_name: "${{ secrets.CACHIX_CACHE_NAME }}"
           cachix_auth_token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - name: build
-        run: just ci just test
+      - name: "Build & Test Images"
+        run: just ci just maintenance::test-images

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,13 +37,13 @@ For all task, enter a development shell with `just develop`.
 You can run tests with
 
 ```bash
-just test
+just maintenance::test
 ```
 
 Note: You can `REPOSITORY_TEMPLATE_UPDATE_FLAKE=true just ...` to update the Nix
 flake before the tests to update dependencies.
 
-To test single templates use `just maintenance test [generic|go|python|rust]`.
+To test single templates use `just maintenance::test [generic|go|python|rust]`.
 
 ### Push the Templates
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,13 @@ For all task, enter a development shell with `just develop`.
 You can run tests with
 
 ```bash
-just maintenance test-all
+just test
 ```
 
 Note: You can `REPOSITORY_TEMPLATE_UPDATE_FLAKE=true just ...` to update the Nix
 flake before the tests to update dependencies.
+
+To test single templates use `just maintenance test [generic|go|python|rust]`.
 
 ### Push the Templates
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Repository Template
   <a href="https://github.com/sdsc-ordes/repository-template/releases/latest">
     <img src="https://img.shields.io/github/release/sdsc-ordes/repository-template.svg?label=release" alt="Current Release" />
   </a>
-  <a href="https://github.com/swissdatasciencecenter/ my-project/actions/workflows/main-and-pr.yaml">
+  <a href="https://github.com/swissdatasciencecenter/ my-project/actions/workflows/normal.yaml">
     <img src="https://img.shields.io/github/actions/workflow/status/sdsc-ordes/repository-template/main-and-pr.yaml?label=ci" alt="Pipeline Status" />
   </a>
   <a href="http://www.apache.org/licenses/LICENSE-2.0.html">

--- a/justfile
+++ b/justfile
@@ -44,6 +44,10 @@ nix-list *args:
 develop *args:
     just nix-develop default "$@"
 
+# Enter the CI Nix development shell.
+ci *args:
+    just nix-develop ci "$@"
+
 # Enter the Nix development shell `$1` and execute the command `${@:2}`.
 [private]
 nix-develop *args:

--- a/justfile
+++ b/justfile
@@ -32,10 +32,6 @@ clean:
 test:
    just maintenance::test-all
 
-# Test a template.
-test-single template="python":
-   just maintenance::test "{{template}}"
-
 # Show all packages configured in the Nix `flake.nix`.
 nix-list *args:
     cd tools/nix && nix flake --no-pure-eval show

--- a/src/generic/LICENSE.md.jinja
+++ b/src/generic/LICENSE.md.jinja
@@ -1,4 +1,5 @@
 {%- if project_license == "mit" %}
+<!-- SPDX-License-Identifier: MIT -->
 # The MIT License (MIT)
 
 Copyright © {% now 'utc', '%Y' %} - {{ project_affiliation }}
@@ -20,6 +21,7 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 {%- elif project_license == "apache2" %}
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 Apache License
 ==============
 

--- a/src/generic/README.md.jinja
+++ b/src/generic/README.md.jinja
@@ -11,7 +11,7 @@
 {% for host in project_hosts[0:1] %}
 {%- if "github" in host.host %}
 [![Current Release](https://img.shields.io/github/release/{{ host.organization }}/{{ host.repo }}.svg?label=release)](https://{{ host.host }}/{{ host.organization }}/{{ host.repo }}/releases/latest)
-[![Pipeline Status](https://img.shields.io/github/actions/workflow/status/{{ host.organization }}/{{ host.repo }}/main-and-pr.yaml?label=ci)](https://{{ host.host }}/{{ host.organization }}/{{ host.repo }}/actions/workflows/main-and-pr.yaml)
+[![Pipeline Status](https://img.shields.io/github/actions/workflow/status/{{ host.organization }}/{{ host.repo }}/normal.yaml?label=ci)](https://{{ host.host }}/{{ host.organization }}/{{ host.repo }}/actions/workflows/normal.yaml)
 {%- elif "gitlab" in host.host %}
 [![Current Release](https://{{ host.host }}/{{ host.organization }}/{{ host.repo }}/-/badges/release.svg)](https://{{ host.host }}/{{ host.organization }}/{{ host.repo }}/-/releases)
 [![Pipeline Status](https://{{ host.host }}/{{ host.organization }}/{{ host.repo }}/badges/main/pipeline.svg)](https://{{ host.host }}/{{ host.organization }}/{{ host.repo }}/-/pipelines)

--- a/src/generic/tools/nix/flake.lock
+++ b/src/generic/tools/nix/flake.lock
@@ -320,11 +320,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1743093505,
-        "narHash": "sha256-JqrkanTUl369dn1GRU9bsyZJUq1epuR/CVsvUAt9aJw=",
+        "lastModified": 1743210254,
+        "narHash": "sha256-WSair8Op8eOoMX8DYCSdfSLLV4AGOaPmnyJQZ/qRBIs=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "a26a15d05c5ac198c369a830acc063c7524e04db",
+        "rev": "3f13cc0f8739a1a70e52326af9ec49cee536128a",
         "type": "github"
       },
       "original": {
@@ -399,11 +399,11 @@
     },
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1742937945,
-        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
+        "lastModified": 1743367904,
+        "narHash": "sha256-sOos1jZGKmT6xxPvxGQyPTApOunXvScV4lNjBCXd/CI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
+        "rev": "7ffe0edc685f14b8c635e3d6591b0bbb97365e6c",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1742889210,
-        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
         "type": "github"
       },
       "original": {

--- a/src/generic/tools/nix/flake.lock
+++ b/src/generic/tools/nix/flake.lock
@@ -35,19 +35,20 @@
         "git-hooks": "git-hooks",
         "nix": "nix",
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgsDevenv"
         ]
       },
       "locked": {
-        "lastModified": 1742214310,
-        "narHash": "sha256-n5bdCsgv7+EtBH8R1rNEMPHskdHtTdm2tPHs0Hwle8s=",
+        "lastModified": 1739852725,
+        "narHash": "sha256-OjdnHKQ+eWA8YvPUpl3xxyaNK91c9sMebqXgVdN8Lm4=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "52db4dfc65cb0bc527dea0cc92aa475acf4e8f7f",
+        "rev": "98b99188b1539c0d2a45e0a0a161a7b8e797caac",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
+        "ref": "latest",
         "repo": "devenv",
         "type": "github"
       }
@@ -192,11 +193,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740849354,
-        "narHash": "sha256-oy33+t09FraucSZ2rZ6qnD1Y1c8azKKmQuCvF2ytUko=",
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4a709a8ce9f8c08fa7ddb86761fe488ff7858a07",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {
@@ -319,11 +320,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1742159602,
-        "narHash": "sha256-Fr3KNT1lMw6zWgm+oHp2wgFj9TLJXsRZHozk6vv/9Ow=",
+        "lastModified": 1743093505,
+        "narHash": "sha256-JqrkanTUl369dn1GRU9bsyZJUq1epuR/CVsvUAt9aJw=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "2cfd0315113edebefc38dd7f9d7dd57599629dc6",
+        "rev": "a26a15d05c5ac198c369a830acc063c7524e04db",
         "type": "github"
       },
       "original": {
@@ -380,13 +381,29 @@
         "type": "github"
       }
     },
+    "nixpkgsDevenv": {
+      "locked": {
+        "lastModified": 1733477122,
+        "narHash": "sha256-qamMCz5mNpQmgBwc8SB5tVMlD5sbwVIToVZtSxMph9s=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "7bd9e84d0452f6d2e63b6e6da29fe73fac951857",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1742136038,
-        "narHash": "sha256-DDe16FJk18sadknQKKG/9FbwEro7A57tg9vB5kxZ8kY=",
+        "lastModified": 1742937945,
+        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a1185f4064c18a5db37c5c84e5638c78b46e3341",
+        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
         "type": "github"
       },
       "original": {
@@ -414,11 +431,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1742069588,
-        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
+        "lastModified": 1742889210,
+        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
+        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
         "type": "github"
       },
       "original": {
@@ -433,6 +450,7 @@
         "devenv": "devenv",
         "nix": "nix_2",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgsDevenv": "nixpkgsDevenv",
         "nixpkgsStable": "nixpkgsStable",
         "snowfall-lib": "snowfall-lib",
         "treefmt-nix": "treefmt-nix"
@@ -483,11 +501,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739829690,
-        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "lastModified": 1743081648,
+        "narHash": "sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "rev": "29a3d7b768c70addce17af0869f6e2bd8f5be4b7",
         "type": "github"
       },
       "original": {

--- a/src/generic/tools/nix/flake.lock
+++ b/src/generic/tools/nix/flake.lock
@@ -320,11 +320,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1743210254,
-        "narHash": "sha256-WSair8Op8eOoMX8DYCSdfSLLV4AGOaPmnyJQZ/qRBIs=",
+        "lastModified": 1743489973,
+        "narHash": "sha256-v3Wua1bv77s4gsWHrLZKWu09PqjSYoLIMAclF7ZpdeI=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "3f13cc0f8739a1a70e52326af9ec49cee536128a",
+        "rev": "6fe39566d2893e790c9ce8077d067f32b1b7b49a",
         "type": "github"
       },
       "original": {

--- a/src/generic/tools/nix/flake.lock
+++ b/src/generic/tools/nix/flake.lock
@@ -447,15 +447,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1736130495,
-        "narHash": "sha256-4i9nAJEZFv7vZMmrE0YG55I3Ggrtfo5/T07JEpEZ/RM=",
+        "lastModified": 1718097323,
+        "narHash": "sha256-zCgs8Wp7rdt0tjNUHMUIvi6sIvDoprWIHwvTGq+LMK0=",
         "owner": "snowfallorg",
         "repo": "lib",
-        "rev": "02d941739f98a09e81f3d2d9b3ab08918958beac",
+        "rev": "aa19b02b63025263cec041fcb7a0857c3cb98859",
         "type": "github"
       },
       "original": {
         "owner": "snowfallorg",
+        "ref": "v3.0.3",
         "repo": "lib",
         "type": "github"
       }

--- a/src/generic/tools/nix/flake.nix.jinja
+++ b/src/generic/tools/nix/flake.nix.jinja
@@ -36,15 +36,16 @@
         url = "github:cachix/devenv/latest";
         inputs.nixpkgs.follows = "nixpkgsDevenv";
     };
-    # We have to lock somehow the pkgs in `mkShell` here:
+    # We should lock the pkgs in `mkShell` here:
     # https://github.com/cachix/devenv/issues/1797
-    # `nixpkgs` is used in the devShell modules.
+    # to devenvs rolling nixpkgs. Note: that does not restrict the use of
+    # 'nixpkgs' input in devenv modules.
     nixpkgsDevenv.url = "github:cachix/devenv-nixpkgs/rolling";
 
     # Snowfall provides a structured way of creating a flake output.
     # Documentation: https://snowfall.org/guides/lib/quickstart/
     snowfall-lib = {
-      url = "github:snowfallorg/lib/latest";
+      url = "github:snowfallorg/lib?ref=v3.0.3";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/src/generic/tools/nix/flake.nix.jinja
+++ b/src/generic/tools/nix/flake.nix.jinja
@@ -34,8 +34,12 @@
     # The devenv module to create good development shells.
     devenv = {
         url = "github:cachix/devenv/latest";
-        inputs.nixpkgs.follows = "nixpkgs";
+        inputs.nixpkgs.follows = "nixpkgsDevenv";
     };
+    # We have to lock somehow the pkgs in `mkShell` here:
+    # https://github.com/cachix/devenv/issues/1797
+    # `nixpkgs` is used in the devShell modules.
+    nixpkgsDevenv.url = "github:cachix/devenv-nixpkgs/rolling";
 
     # Snowfall provides a structured way of creating a flake output.
     # Documentation: https://snowfall.org/guides/lib/quickstart/

--- a/src/generic/tools/nix/flake.nix.jinja
+++ b/src/generic/tools/nix/flake.nix.jinja
@@ -2,12 +2,14 @@
   description = "repository-template";
 
   nixConfig = {
-    extra-substituters = [
+    extra-trusted-substituters = [
       # Nix community's cache server
       "https://nix-community.cachix.org"
+      "https://devenv.cachix.org"
     ];
     extra-trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
     ];
   };
 
@@ -31,15 +33,15 @@
 
     # The devenv module to create good development shells.
     devenv = {
-        url = "github:cachix/devenv";
+        url = "github:cachix/devenv/latest";
         inputs.nixpkgs.follows = "nixpkgs";
     };
 
     # Snowfall provides a structured way of creating a flake output.
     # Documentation: https://snowfall.org/guides/lib/quickstart/
     snowfall-lib = {
-        url = "github:snowfallorg/lib";
-        inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:snowfallorg/lib/latest";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     {% if project_language == "rust" %}

--- a/src/generic/tools/nix/lib/default.nix
+++ b/src/generic/tools/nix/lib/default.nix
@@ -1,39 +1,8 @@
 {
   lib,
-  namespace,
   ...
 }:
-with lib;
 let
-  # List all toolchain files in `dir` (returns `{ "toolchain-go.nix" = "regular", ...  }`  )
-  toolchain-files =
-    dir:
-    attrsets.filterAttrs (
-      k: v: strings.hasPrefix "toolchain-" k && strings.hasSuffix ".nix" k && v == "regular"
-    ) (builtins.readDir dir);
-
-  # Modifies into `{ "go" = {"path" = ...; }, ... }`
-  toolchains =
-    dir:
-    attrsets.concatMapAttrs (
-      k: v:
-      let
-        language = strings.removeSuffix ".nix" (strings.removePrefix "toolchain-" k);
-      in
-      {
-        ${language} = {
-          path = dir + "/${k}";
-        };
-      }
-    ) (toolchain-files dir);
-
-  # Import all toolchains.
-  import-all =
-    dir: args:
-    attrsets.concatMapAttrs (lang: file: {
-      ${lang} = (import file.path) args;
-    }) (toolchains dir);
-
   repo-root = ./../../..;
 in
 {
@@ -44,9 +13,8 @@ in
   };
 
   # Toolchain functionality.
-  toolchain = {
-    # Imports all files `toolchain-<language>.nix` which define a list of language specific
-    # packages, returns `{ "go" = [...];, "python" = [...]; }`.
-    import = dir: args: import-all dir args;
-  };
+  toolchain = import ./toolchain-files.nix { inherit lib; };
+
+  # Shell functionality.
+  shell = import ./shell.nix { inherit lib; };
 }

--- a/src/generic/tools/nix/lib/shell.nix
+++ b/src/generic/tools/nix/lib/shell.nix
@@ -1,14 +1,9 @@
-{ lib, ... }:
-let
-  fs = lib.fileset;
-in
-rec {
-  rootDir = ../../..;
-  rootFileset = fs.fromSource rootDir;
-
+{ ... }:
+{
   # Define a `devenv` shell.
-  # Pin the `pkgs` to the nixpkgsDevenv inputs.
-  makeShell =
+  # Pin the `pkgs` to the nixpkgsDevenv inputs to make it
+  # more stable.
+  mkShell =
     {
       inputs,
       system,

--- a/src/generic/tools/nix/lib/toolchain-files.nix
+++ b/src/generic/tools/nix/lib/toolchain-files.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  ...
+}:
+with lib;
+let
+  # List all toolchain files in `dir` (returns `{ "toolchain-go.nix" = "regular", ...  }`  )
+  toolchain-files =
+    dir:
+    attrsets.filterAttrs (
+      k: v: strings.hasPrefix "toolchain-" k && strings.hasSuffix ".nix" k && v == "regular"
+    ) (builtins.readDir dir);
+
+  # Modifies into `{ "go" = {"path" = ...; }, ... }`
+  toolchains =
+    dir:
+    attrsets.concatMapAttrs (
+      k: v:
+      let
+        language = strings.removeSuffix ".nix" (strings.removePrefix "toolchain-" k);
+      in
+      {
+        ${language} = {
+          path = dir + "/${k}";
+        };
+      }
+    ) (toolchain-files dir);
+
+  # Import all toolchains.
+  import-all =
+    dir: args:
+    attrsets.concatMapAttrs (lang: file: {
+      ${lang} = (import file.path) args;
+    }) (toolchains dir);
+in
+{
+  # Imports all files `toolchain-<language>.nix` which define a list of language specific
+  # packages, returns `{ "go" = [...];, "python" = [...]; }`.
+  import = dir: args: import-all dir args;
+}

--- a/src/generic/tools/nix/shells/ci/default.nix
+++ b/src/generic/tools/nix/shells/ci/default.nix
@@ -10,6 +10,7 @@ let
 in
 # Create the 'ci' shell.
 inputs.devenv.lib.mkShell {
-  inherit pkgs inputs;
+  inherit inputs;
+  pkgs = inputs.nixpkgsDevenv.legacyPackages.${pkgs.system};
   modules = toolchains.ci;
 }

--- a/src/generic/tools/nix/shells/ci/default.nix
+++ b/src/generic/tools/nix/shells/ci/default.nix
@@ -9,8 +9,8 @@ let
   toolchains = import ../toolchain.nix { inherit lib pkgs namespace; };
 in
 # Create the 'ci' shell.
-inputs.devenv.lib.mkShell {
+lib.${namespace}.shell.mkShell {
+  inherit (pkgs) system;
   inherit inputs;
-  pkgs = inputs.nixpkgsDevenv.legacyPackages.${pkgs.system};
   modules = toolchains.ci;
 }

--- a/src/generic/tools/nix/shells/default/default.nix
+++ b/src/generic/tools/nix/shells/default/default.nix
@@ -10,6 +10,7 @@ let
 in
 # Create the 'default' shell.
 inputs.devenv.lib.mkShell {
-  inherit pkgs inputs;
+  inherit inputs;
+  pkgs = inputs.nixpkgsDevenv.legacyPackages.${pkgs.system};
   modules = toolchains.default;
 }

--- a/src/generic/tools/nix/shells/default/default.nix
+++ b/src/generic/tools/nix/shells/default/default.nix
@@ -9,8 +9,8 @@ let
   toolchains = import ../toolchain.nix { inherit lib pkgs namespace; };
 in
 # Create the 'default' shell.
-inputs.devenv.lib.mkShell {
+lib.${namespace}.shell.mkShell {
+  inherit (pkgs) system;
   inherit inputs;
-  pkgs = inputs.nixpkgsDevenv.legacyPackages.${pkgs.system};
   modules = toolchains.default;
 }

--- a/src/generic/tools/nix/shells/format/default.nix
+++ b/src/generic/tools/nix/shells/format/default.nix
@@ -6,7 +6,8 @@
 }:
 # Create the 'format' shell.
 inputs.devenv.lib.mkShell {
-  inherit pkgs inputs;
+  inherit inputs;
+  pkgs = inputs.nixpkgsDevenv.legacyPackages.${pkgs.system};
   modules = [
     (
       { pkgs, ... }:

--- a/src/generic/tools/nix/shells/format/default.nix
+++ b/src/generic/tools/nix/shells/format/default.nix
@@ -1,13 +1,14 @@
 {
+  lib,
   pkgs,
   namespace,
   inputs,
   ...
 }:
 # Create the 'format' shell.
-inputs.devenv.lib.mkShell {
+lib.${namespace}.shell.mkShell {
+  inherit (pkgs) system;
   inherit inputs;
-  pkgs = inputs.nixpkgsDevenv.legacyPackages.${pkgs.system};
   modules = [
     (
       { pkgs, ... }:

--- a/src/generic/tools/nix/shells/toolchain-generic.nix
+++ b/src/generic/tools/nix/shells/toolchain-generic.nix
@@ -1,12 +1,19 @@
-{ pkgs, namespace, ... }:
+# This function returns a list of `devenv` modules
+# which are passed to `mkShell`.
+#
+# Search for package at:
+# https://search.nixos.org/packages
+{
+  # These are `pkgs` from `input.nixpkgs`.
+  pkgs,
+  namespace,
+  ...
+}:
 [
-  (
-    { ... }:
-    {
-      packages = [
-        pkgs.${namespace}.bootstrap
-        pkgs.${namespace}.treefmt
-      ];
-    }
-  )
+  {
+    packages = [
+      pkgs.${namespace}.bootstrap
+      pkgs.${namespace}.treefmt
+    ];
+  }
 ]

--- a/src/generic/tools/nix/shells/toolchain.nix.jinja
+++ b/src/generic/tools/nix/shells/toolchain.nix.jinja
@@ -1,9 +1,7 @@
-# This function defines attrsets with packages
-# to be used in the different development shells
-# in this folder.
-
-# Search for package at:
-# https://search.nixos.org/packages
+# This function loads `toolchain-*.nix` files in this folder
+# and imports them. Each `toolchain-*.nix` file contains a
+# list of `devenv` modules.
+# The function returns all toolchains in an attrset.
 {
   lib,
   pkgs,

--- a/src/go/tools/configs/golangci-lint/golangci.yaml
+++ b/src/go/tools/configs/golangci-lint/golangci.yaml
@@ -1,307 +1,163 @@
-run:
-  # Timeout for analysis, e.g. 30s, 5m.
-  # Default: 1m
-  timeout: 5m
-
-# This file contains only configs which differ from defaults.
-# All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
-linters-settings:
-  cyclop:
-    # The maximal code complexity to report.
-    # Default: 10
-    max-complexity: 30
-    # The maximal average package complexity.
-    # If it's higher than 0.0 (float) the check is enabled
-    # Default: 0.0
-    package-average: 10.0
-
-  errcheck:
-    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
-    # Such cases aren't reported by default.
-    # Default: false
-    check-type-assertions: true
-
-  exhaustive:
-    # Program elements to check for exhaustiveness.
-    # Default: [ switch ]
-    check:
-      - switch
-      - map
-
-  exhaustruct:
-    # List of regular expressions to exclude struct packages and their names from checks.
-    # Regular expressions must match complete canonical struct package/name/structname.
-    # Default: []
-    exclude:
-      # std libs
-      - "^net/http.Client$"
-      - "^net/http.Cookie$"
-      - "^net/http.Request$"
-      - "^net/http.Response$"
-      - "^net/http.Server$"
-      - "^net/http.Transport$"
-      - "^net/url.URL$"
-      - "^os/exec.Cmd$"
-      - "^reflect.StructField$"
-      # public libs
-      - "^github.com/spf13/cobra.Command$"
-      - "^github.com/spf13/cobra.CompletionOptions$"
-
-  funlen:
-    # Checks the number of lines in a function.
-    # If lower than 0, disable the check.
-    # Default: 60
-    lines: 100
-    # Checks the number of statements in a function.
-    # If lower than 0, disable the check.
-    # Default: 40
-    statements: 50
-    # Ignore comments when counting lines.
-    # Default false
-    ignore-comments: true
-
-  gocognit:
-    # Minimal code complexity to report.
-    # Default: 30 (but we recommend 10-20)
-    min-complexity: 20
-
-  gocritic:
-    # Settings passed to gocritic.
-    # The settings key is the name of a supported gocritic checker.
-    # The list of supported checkers can be find in https://go-critic.github.io/overview.
-    settings:
-      captLocal:
-        # Whether to restrict checker to params only.
-        # Default: true
-        paramsOnly: false
-      underef:
-        # Whether to skip (*x).method() calls where x is a pointer receiver.
-        # Default: true
-        skipRecvDeref: false
-
-  govet:
-    # Enable all analyzers.
-    # Default: false
-    enable-all: true
-    # Disable analyzers by name.
-    # Run `go tool vet help` to see all analyzers.
-    # Default: []
-    disable:
-      - fieldalignment # too strict
-    # Settings per analyzer.
-    settings:
-      shadow:
-        # Whether to be strict about shadowing; can be noisy.
-        # Default: false
-        strict: true
-
-  inamedparam:
-    # Skips check for interface methods with only a single parameter.
-    # Default: false
-    skip-single-param: true
-
-  mnd:
-    # List of function patterns to exclude from analysis.
-    # Values always ignored: `time.Date`,
-    # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
-    # `strconv.ParseInt`, `strconv.ParseUint`, `strconv.ParseFloat`.
-    # Default: []
-    ignored-functions:
-      - args.Error
-      - flag.Arg
-      - flag.Duration.*
-      - flag.Float.*
-      - flag.Int.*
-      - flag.Uint.*
-      - os.Chmod
-      - os.Mkdir.*
-      - os.OpenFile
-      - os.WriteFile
-
-  nakedret:
-    # Make an issue if func has more lines of code than this setting, and it has naked returns.
-    # Default: 30
-    max-func-lines: 50
-
-  nolintlint:
-    # Exclude following linters from requiring an explanation.
-    # Default: []
-    allow-no-explanation: [funlen, gocognit, lll, mnd]
-    # Enable to require an explanation of nonzero length after each nolint directive.
-    # Default: false
-    require-explanation: true
-    # Enable to require nolint directives to mention the specific linter being suppressed.
-    # Default: false
-    require-specific: true
-
-  perfsprint:
-    # Optimizes into strings concatenation.
-    # Default: true
-    strconcat: false
-
-  sloglint:
-    # Enforce not using global loggers.
-    # Values:
-    # - "": disabled
-    # - "all": report all global loggers
-    # - "default": report only the default slog logger
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-global
-    # Default: ""
-    no-global: "all"
-    # Enforce using methods that accept a context.
-    # Values:
-    # - "": disabled
-    # - "all": report all contextless calls
-    # - "scope": report only if a context exists in the scope of the outermost function
-    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#context-only
-    # Default: ""
-    context: "scope"
-
-  gomodguard:
-    blocked:
-      modules:
-        # Define here your modules you want to suggest instead of using
-        # wrong ones.
-
-  tagliatelle:
-    case:
-      rules:
-        json: goCamel
-        yaml: goCamel
-
-  tenv:
-    # The option `all` will run against whole test files (`_test.go`)
-    # regardless of method/function signatures.
-    # Otherwise, only methods that take `*testing.T`, `*testing.B`,
-    # and `testing.TB` as arguments are checked.
-    # Default: false
-    all: true
-
-  revive:
-    rules:
-      - name: unused-parameter
-        arguments:
-          - allowRegex: "^_"
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - asasalint # checks for pass []any as any in variadic func(...any)
-    - asciicheck # checks that your code does not contain non-ASCII identifiers
-    - bidichk # checks for dangerous unicode character sequences
-    - bodyclose # checks whether HTTP response body is closed successfully
-    - canonicalheader # checks whether net/http.Header uses canonical header
-    - copyloopvar # detects places where loop variables are copied (Go 1.22+)
-    - cyclop # checks function and package cyclomatic complexity
-    - dupl # tool for code clone detection
-    - durationcheck # checks for two durations multiplied together
-    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
-    - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
-    - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
-    - exhaustive # checks exhaustiveness of enum switch statements
-    - fatcontext # detects nested contexts in loops
-    - forbidigo # forbids identifiers
-    - funlen # tool for detection of long functions
-    - gocheckcompilerdirectives # validates go compiler directive comments (//go:)
-    - gochecknoglobals # checks that no global variables exist
-    - gochecknoinits # checks that no init functions are present in Go code
-    - gochecksumtype # checks exhaustiveness on Go "sum types"
-    - gocognit # computes and checks the cognitive complexity of functions
-    - goconst # finds repeated strings that could be replaced by a constant
-    - gocritic # provides diagnostics that check for bugs, performance and style issues
-    - gocyclo # computes and checks the cyclomatic complexity of functions
-    - godot # checks if comments end in a period
-    - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
-    - gomodguard # allow and block lists linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations
-    - goprintffuncname # checks that printf-like functions are named with f at the end
-    - gosec # inspects source code for security problems
-    - gosimple # specializes in simplifying a code
-    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    - ineffassign # detects when assignments to existing variables are not used
-    - intrange # finds places where for loops could make use of an integer range
-    - lll # reports long lines
-    - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
-    - makezero # finds slice declarations with non-zero initial length
-    - mirror # reports wrong mirror patterns of bytes/strings usage
-    - mnd # detects magic numbers
-    - nakedret # finds naked returns in functions greater than a specified function length
-    - nestif # reports deeply nested if statements
-    - nilerr # finds the code that returns nil even if it checks that the error is not nil
-    - nilnil # checks that there is no simultaneous return of nil error and an invalid value
-    - nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
-    - noctx # finds sending http request without context.Context
-    - nolintlint # reports ill-formed or insufficient nolint directives
-    - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
-    - perfsprint # checks that fmt.Sprintf can be replaced with a faster alternative
-    - predeclared # finds code that shadows one of Go's predeclared identifiers
-    - promlinter # checks Prometheus metrics naming via promlint
-    - protogetter # reports direct reads from proto message fields when getters should be used
-    - reassign # checks that package variables are not reassigned
-    - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
-    - rowserrcheck # checks whether Err of rows is checked successfully
-    - sloglint # ensure consistent code style when using log/slog
-    - spancheck # checks for mistakes with OpenTelemetry/Census spans
-    - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
-    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
-    - stylecheck # is a replacement for golint
-    - tagliatelle # checks the struct tags
-    - tenv # detects using os.Setenv instead of t.Setenv since Go1.17
-    - testableexamples # checks if examples are testable (have an expected output)
-    - testifylint # checks usage of github.com/stretchr/testify
-    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
-    - typecheck # like the front-end of a Go compiler, parses and type-checks Go code
-    - unconvert # removes unnecessary type conversions
-    - unparam # reports unused function parameters
-    - unused # checks for unused constants, variables, functions and types
-    - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
-    - wastedassign # finds wasted assignment statements
-    - whitespace # detects leading and trailing whitespace
-
-    ## you may want to enable
-    # - gomoddirectives  # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
-    # - nonamedreturns  # reports all named returns
-    # - depguard  # [replaced by gomodguard] checks if package imports are in a list of acceptable packages
-    # - musttag  # enforces field tags in (un)marshaled structs
-    # - testpackage  # makes you use a separate _test package
-    # - decoder  # checks declaration order and count of types, constants, variables and functions
-    # - exhaustruct  # [highly recommend to enable] checks if all structure fields are initialized
-    # - gci  # controls golang package import order and makes it always deterministic
-    # - ginkgolinter  # [if you use ginkgo/gomega] enforces standards of using ginkgo and gomega
-    # - godox  # detects FIXME, TODO and other comment keywords
-    # - goheader  # checks is file header matches to pattern
-    # - inamedparam  # [great idea, but too strict, need to ignore a lot of cases by default] reports interfaces with unnamed method parameters
-    # - interfacebloat  # checks the number of methods inside an interface
-    # - ireturn  # accept interfaces, return concrete types
-    # - prealloc  # [premature optimization, but can be used in some cases] finds slice declarations that could potentially be preallocated
-    # - tagalign  # checks that struct tags are well aligned
-    # - varnamelen  # [great idea, but too many false positives] checks that the length of a variable's name matches its scope
-    # - wrapcheck  # checks that errors returned from external packages are wrapped
-    # - zerologlint  # detects the wrong usage of zerolog that a user forgets to dispatch zerolog.Event
-
-    ## disabled
-    # - containedctx  # detects struct contained context.Context field
-    # - contextcheck  # [too many false positives] checks the function whether use a non-inherited context
-    # - dogsled  # checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
-    # - dupword  # [useless without config] checks for duplicate words in the source code
-    # - err113  # [too strict] checks the errors handling expressions
-    # - errchkjson  # [don't see profit + I'm against of omitting errors like in the first example https://github.com/breml/errchkjson] checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted
-    # - execinquery  # [deprecated] checks query string in Query function which reads your Go src files and warning it finds
-    # - exportloopref  # [not necessary from Go 1.22] checks for pointers to enclosing loop variables
-    # - forcetypeassert  # [replaced by errcheck] finds forced type assertions
-    # - gofmt  # [replaced by goimports] checks whether code was gofmt-ed
-    # - gofumpt  # [replaced by goimports, gofumports is not available yet] checks whether code was gofumpt-ed
-    # - gosmopolitan  # reports certain i18n/l10n anti-patterns in your Go codebase
-    # - grouper  # analyzes expression groups
-    # - imports  # enforces consistent import aliases
-    # - maintidx  # measures the maintainability index of each function
-    # - misspell  # [useless] finds commonly misspelled English words in comments
-    # - paralleltest  # [too many false positives] detects missing usage of t.Parallel() method in your Go test
-    # - tagliatelle  # checks the struct tags
-    # - thelper  # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
-    # - wsl  # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
-
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - canonicalheader
+    - copyloopvar
+    - cyclop
+    - dupl
+    - durationcheck
+    - errcheck
+    - errname
+    - errorlint
+    - exhaustive
+    - fatcontext
+    - forbidigo
+    - funlen
+    - gocheckcompilerdirectives
+    - gochecknoglobals
+    - gochecknoinits
+    - gochecksumtype
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - govet
+    - ineffassign
+    - intrange
+    - lll
+    - loggercheck
+    - makezero
+    - mirror
+    - mnd
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - nlreturn
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - perfsprint
+    - predeclared
+    - promlinter
+    - protogetter
+    - reassign
+    - revive
+    - rowserrcheck
+    - sloglint
+    - spancheck
+    - sqlclosecheck
+    - staticcheck
+    - tagliatelle
+    - testableexamples
+    - testifylint
+    - tparallel
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - wastedassign
+    - whitespace
+  settings:
+    cyclop:
+      max-complexity: 30
+      package-average: 10
+    errcheck:
+      check-type-assertions: true
+    exhaustive:
+      check:
+        - switch
+        - map
+    exhaustruct:
+      exclude:
+        - ^net/http.Client$
+        - ^net/http.Cookie$
+        - ^net/http.Request$
+        - ^net/http.Response$
+        - ^net/http.Server$
+        - ^net/http.Transport$
+        - ^net/url.URL$
+        - ^os/exec.Cmd$
+        - ^reflect.StructField$
+        - ^github.com/spf13/cobra.Command$
+        - ^github.com/spf13/cobra.CompletionOptions$
+    funlen:
+      lines: 100
+      statements: 50
+      ignore-comments: true
+    gocognit:
+      min-complexity: 20
+    gocritic:
+      settings:
+        captLocal:
+          paramsOnly: false
+        underef:
+          skipRecvDeref: false
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
+      settings:
+        shadow:
+          strict: true
+    inamedparam:
+      skip-single-param: true
+    mnd:
+      ignored-functions:
+        - args.Error
+        - flag.Arg
+        - flag.Duration.*
+        - flag.Float.*
+        - flag.Int.*
+        - flag.Uint.*
+        - os.Chmod
+        - os.Mkdir.*
+        - os.OpenFile
+        - os.WriteFile
+    nakedret:
+      max-func-lines: 50
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-no-explanation:
+        - funlen
+        - gocognit
+        - lll
+        - mnd
+    perfsprint:
+      strconcat: false
+    revive:
+      rules:
+        - name: unused-parameter
+          arguments:
+            - allowRegex: ^_
+    sloglint:
+      no-global: all
+      context: scope
+    tagliatelle:
+      case:
+        rules:
+          json: goCamel
+          yaml: goCamel
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # Maximum count of issues with the same text.
-  # Set to 0 to disable.
-  # Default: 3
   max-same-issues: 100

--- a/src/go/tools/configs/golangci-lint/golangci.yaml
+++ b/src/go/tools/configs/golangci-lint/golangci.yaml
@@ -2,71 +2,71 @@ version: "2"
 linters:
   default: none
   enable:
-    - asasalint
-    - asciicheck
-    - bidichk
-    - bodyclose
-    - canonicalheader
-    - copyloopvar
-    - cyclop
-    - dupl
-    - durationcheck
-    - errcheck
-    - errname
-    - errorlint
-    - exhaustive
-    - fatcontext
-    - forbidigo
-    - funlen
-    - gocheckcompilerdirectives
-    - gochecknoglobals
-    - gochecknoinits
-    - gochecksumtype
-    - gocognit
-    - goconst
-    - gocritic
-    - gocyclo
-    - godot
-    - gomodguard
-    - goprintffuncname
-    - gosec
-    - govet
-    - ineffassign
-    - intrange
-    - lll
-    - loggercheck
-    - makezero
-    - mirror
-    - mnd
-    - nakedret
-    - nestif
-    - nilerr
-    - nilnil
-    - nlreturn
-    - noctx
-    - nolintlint
-    - nosprintfhostport
-    - perfsprint
-    - predeclared
-    - promlinter
-    - protogetter
-    - reassign
-    - revive
-    - rowserrcheck
-    - sloglint
-    - spancheck
-    - sqlclosecheck
-    - staticcheck
-    - tagliatelle
-    - testableexamples
-    - testifylint
-    - tparallel
-    - unconvert
-    - unparam
-    - unused
-    - usestdlibvars
-    - wastedassign
-    - whitespace
+    - asasalint # checks for pass []any as any in variadic func(...any)
+    - asciicheck # checks that your code does not contain non-ASCII identifiers
+    - bidichk # checks for dangerous unicode character sequences
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - canonicalheader # checks whether net/http.Header uses canonical header
+    - copyloopvar # detects places where loop variables are copied (Go 1.22+)
+    - cyclop # checks function and package cyclomatic complexity
+    - dupl # tool for code clone detection
+    - durationcheck # checks for two durations multiplied together
+    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
+    - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
+    - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
+    - exhaustive # checks exhaustiveness of enum switch statements
+    - fatcontext # detects nested contexts in loops
+    - forbidigo # forbids identifiers
+    - funlen # tool for detection of long functions
+    - gocheckcompilerdirectives # validates go compiler directive comments (//go:)
+    - gochecknoglobals # checks that no global variables exist
+    - gochecknoinits # checks that no init functions are present in Go code
+    - gochecksumtype # checks exhaustiveness on Go "sum types"
+    - gocognit # computes and checks the cognitive complexity of functions
+    - goconst # finds repeated strings that could be replaced by a constant
+    - gocritic # provides diagnostics that check for bugs, performance and style issues
+    - gocyclo # computes and checks the cyclomatic complexity of functions
+    - godot # checks if comments end in a period
+    - gomodguard # allow and block lists linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations
+    - goprintffuncname # checks that printf-like functions are named with f at the end
+    - gosec # inspects source code for security problems
+    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - ineffassign # detects when assignments to existing variables are not used
+    - intrange # finds places where for loops could make use of an integer range
+    - lll # reports long lines
+    - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
+    - makezero # finds slice declarations with non-zero initial length
+    - mirror # reports wrong mirror patterns of bytes/strings usage
+    - mnd # detects magic numbers
+    - nakedret # finds naked returns in functions greater than a specified function length
+    - nestif # reports deeply nested if statements
+    - nilerr # finds the code that returns nil even if it checks that the error is not nil
+    - nilnil # checks that there is no simultaneous return of nil error and an invalid value
+    - nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
+    - noctx # finds sending http request without context.Context
+    - nolintlint # reports ill-formed or insufficient nolint directives
+    - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
+    - perfsprint # checks that fmt.Sprintf can be replaced with a faster alternative
+    - predeclared # finds code that shadows one of Go's predeclared identifiers
+    - promlinter # checks Prometheus metrics naming via promlint
+    - protogetter # reports direct reads from proto message fields when getters should be used
+    - reassign # checks that package variables are not reassigned
+    - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
+    - rowserrcheck # checks whether Err of rows is checked successfully
+    - sloglint # ensure consistent code style when using log/slog
+    - spancheck # checks for mistakes with OpenTelemetry/Census spans
+    - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
+    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
+    - tagliatelle # checks the struct tags
+    - testableexamples # checks if examples are testable (have an expected output)
+    - testifylint # checks usage of github.com/stretchr/testify
+    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
+    - unconvert # removes unnecessary type conversions
+    - unparam # reports unused function parameters
+    - unused # checks for unused constants, variables, functions and types
+    - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
+    - wastedassign # finds wasted assignment statements
+    - whitespace # detects leading and trailing whitespace
   settings:
     cyclop:
       max-complexity: 30

--- a/src/go/tools/nix/flake.lock
+++ b/src/go/tools/nix/flake.lock
@@ -35,19 +35,20 @@
         "git-hooks": "git-hooks",
         "nix": "nix",
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgsDevenv"
         ]
       },
       "locked": {
-        "lastModified": 1742214310,
-        "narHash": "sha256-n5bdCsgv7+EtBH8R1rNEMPHskdHtTdm2tPHs0Hwle8s=",
+        "lastModified": 1739852725,
+        "narHash": "sha256-OjdnHKQ+eWA8YvPUpl3xxyaNK91c9sMebqXgVdN8Lm4=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "52db4dfc65cb0bc527dea0cc92aa475acf4e8f7f",
+        "rev": "98b99188b1539c0d2a45e0a0a161a7b8e797caac",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
+        "ref": "latest",
         "repo": "devenv",
         "type": "github"
       }
@@ -380,6 +381,22 @@
         "type": "github"
       }
     },
+    "nixpkgsDevenv": {
+      "locked": {
+        "lastModified": 1733477122,
+        "narHash": "sha256-qamMCz5mNpQmgBwc8SB5tVMlD5sbwVIToVZtSxMph9s=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "7bd9e84d0452f6d2e63b6e6da29fe73fac951857",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgsStable": {
       "locked": {
         "lastModified": 1742136038,
@@ -433,6 +450,7 @@
         "devenv": "devenv",
         "nix": "nix_2",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgsDevenv": "nixpkgsDevenv",
         "nixpkgsStable": "nixpkgsStable",
         "snowfall-lib": "snowfall-lib",
         "treefmt-nix": "treefmt-nix"

--- a/src/go/tools/nix/flake.lock
+++ b/src/go/tools/nix/flake.lock
@@ -193,11 +193,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740849354,
-        "narHash": "sha256-oy33+t09FraucSZ2rZ6qnD1Y1c8azKKmQuCvF2ytUko=",
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4a709a8ce9f8c08fa7ddb86761fe488ff7858a07",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {
@@ -320,11 +320,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1742159602,
-        "narHash": "sha256-Fr3KNT1lMw6zWgm+oHp2wgFj9TLJXsRZHozk6vv/9Ow=",
+        "lastModified": 1743210254,
+        "narHash": "sha256-WSair8Op8eOoMX8DYCSdfSLLV4AGOaPmnyJQZ/qRBIs=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "2cfd0315113edebefc38dd7f9d7dd57599629dc6",
+        "rev": "3f13cc0f8739a1a70e52326af9ec49cee536128a",
         "type": "github"
       },
       "original": {
@@ -399,11 +399,11 @@
     },
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1742136038,
-        "narHash": "sha256-DDe16FJk18sadknQKKG/9FbwEro7A57tg9vB5kxZ8kY=",
+        "lastModified": 1743367904,
+        "narHash": "sha256-sOos1jZGKmT6xxPvxGQyPTApOunXvScV4lNjBCXd/CI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a1185f4064c18a5db37c5c84e5638c78b46e3341",
+        "rev": "7ffe0edc685f14b8c635e3d6591b0bbb97365e6c",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1742069588,
-        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
         "type": "github"
       },
       "original": {
@@ -501,11 +501,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739829690,
-        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "lastModified": 1743081648,
+        "narHash": "sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "rev": "29a3d7b768c70addce17af0869f6e2bd8f5be4b7",
         "type": "github"
       },
       "original": {

--- a/src/go/tools/nix/flake.lock
+++ b/src/go/tools/nix/flake.lock
@@ -447,15 +447,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1736130495,
-        "narHash": "sha256-4i9nAJEZFv7vZMmrE0YG55I3Ggrtfo5/T07JEpEZ/RM=",
+        "lastModified": 1718097323,
+        "narHash": "sha256-zCgs8Wp7rdt0tjNUHMUIvi6sIvDoprWIHwvTGq+LMK0=",
         "owner": "snowfallorg",
         "repo": "lib",
-        "rev": "02d941739f98a09e81f3d2d9b3ab08918958beac",
+        "rev": "aa19b02b63025263cec041fcb7a0857c3cb98859",
         "type": "github"
       },
       "original": {
         "owner": "snowfallorg",
+        "ref": "v3.0.3",
         "repo": "lib",
         "type": "github"
       }

--- a/src/go/tools/nix/shells/toolchain-go.nix
+++ b/src/go/tools/nix/shells/toolchain-go.nix
@@ -1,43 +1,40 @@
-# This function defines attrsets with packages
-# to be used in the different development shells
-# in this folder.
-
+# This function returns a list of `devenv` modules
+# which are passed to `mkShell`.
+#
 # Search for package at:
 # https://search.nixos.org/packages
 {
+  # These are `pkgs` from `input.nixpkgs`.
   pkgs,
   namespace,
   ...
 }:
 [
-  (
-    { ... }:
-    {
-      packages = [
-        pkgs.${namespace}.bootstrap
-        pkgs.${namespace}.treefmt
+  {
+    packages = [
+      pkgs.${namespace}.bootstrap
+      pkgs.${namespace}.treefmt
 
-        # Go.
-        pkgs.go_1_23
+      # Go.
+      pkgs.go_1_23
 
-        # Go debugger.
-        pkgs.delve
-        # Language server.
-        pkgs.gopls
-        # Formatting
-        pkgs.golines
-        # Formatting (goimports)
-        pkgs.gotools
-        # Linting
-        pkgs.golangci-lint
-        pkgs.golangci-lint-langserver
+      # Go debugger.
+      pkgs.delve
+      # Language server.
+      pkgs.gopls
+      # Formatting
+      pkgs.golines
+      # Formatting (goimports)
+      pkgs.gotools
+      # Linting
+      pkgs.golangci-lint
+      pkgs.golangci-lint-langserver
 
-        # Debugging
-        pkgs.lldb_18
-      ];
-      enterShell = ''
-        just setup
-      '';
-    }
-  )
+      # Debugging
+      pkgs.lldb_18
+    ];
+    enterShell = ''
+      just setup
+    '';
+  }
 ]

--- a/src/python/tools/nix/flake.lock
+++ b/src/python/tools/nix/flake.lock
@@ -485,15 +485,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1736130495,
-        "narHash": "sha256-4i9nAJEZFv7vZMmrE0YG55I3Ggrtfo5/T07JEpEZ/RM=",
+        "lastModified": 1718097323,
+        "narHash": "sha256-zCgs8Wp7rdt0tjNUHMUIvi6sIvDoprWIHwvTGq+LMK0=",
         "owner": "snowfallorg",
         "repo": "lib",
-        "rev": "02d941739f98a09e81f3d2d9b3ab08918958beac",
+        "rev": "aa19b02b63025263cec041fcb7a0857c3cb98859",
         "type": "github"
       },
       "original": {
         "owner": "snowfallorg",
+        "ref": "v3.0.3",
         "repo": "lib",
         "type": "github"
       }

--- a/src/python/tools/nix/flake.lock
+++ b/src/python/tools/nix/flake.lock
@@ -35,19 +35,20 @@
         "git-hooks": "git-hooks",
         "nix": "nix",
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgsDevenv"
         ]
       },
       "locked": {
-        "lastModified": 1742214310,
-        "narHash": "sha256-n5bdCsgv7+EtBH8R1rNEMPHskdHtTdm2tPHs0Hwle8s=",
+        "lastModified": 1739852725,
+        "narHash": "sha256-OjdnHKQ+eWA8YvPUpl3xxyaNK91c9sMebqXgVdN8Lm4=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "52db4dfc65cb0bc527dea0cc92aa475acf4e8f7f",
+        "rev": "98b99188b1539c0d2a45e0a0a161a7b8e797caac",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
+        "ref": "latest",
         "repo": "devenv",
         "type": "github"
       }
@@ -208,11 +209,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740849354,
-        "narHash": "sha256-oy33+t09FraucSZ2rZ6qnD1Y1c8azKKmQuCvF2ytUko=",
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4a709a8ce9f8c08fa7ddb86761fe488ff7858a07",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {
@@ -335,11 +336,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1742159602,
-        "narHash": "sha256-Fr3KNT1lMw6zWgm+oHp2wgFj9TLJXsRZHozk6vv/9Ow=",
+        "lastModified": 1743093505,
+        "narHash": "sha256-JqrkanTUl369dn1GRU9bsyZJUq1epuR/CVsvUAt9aJw=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "2cfd0315113edebefc38dd7f9d7dd57599629dc6",
+        "rev": "a26a15d05c5ac198c369a830acc063c7524e04db",
         "type": "github"
       },
       "original": {
@@ -417,13 +418,29 @@
         "type": "github"
       }
     },
+    "nixpkgsDevenv": {
+      "locked": {
+        "lastModified": 1733477122,
+        "narHash": "sha256-qamMCz5mNpQmgBwc8SB5tVMlD5sbwVIToVZtSxMph9s=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "7bd9e84d0452f6d2e63b6e6da29fe73fac951857",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1742136038,
-        "narHash": "sha256-DDe16FJk18sadknQKKG/9FbwEro7A57tg9vB5kxZ8kY=",
+        "lastModified": 1742937945,
+        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a1185f4064c18a5db37c5c84e5638c78b46e3341",
+        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
         "type": "github"
       },
       "original": {
@@ -451,11 +468,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1742069588,
-        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
+        "lastModified": 1742889210,
+        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
+        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
         "type": "github"
       },
       "original": {
@@ -471,6 +488,7 @@
         "nix": "nix_2",
         "nixpkgs": "nixpkgs_3",
         "nixpkgs-python": "nixpkgs-python",
+        "nixpkgsDevenv": "nixpkgsDevenv",
         "nixpkgsStable": "nixpkgsStable",
         "snowfall-lib": "snowfall-lib",
         "treefmt-nix": "treefmt-nix"
@@ -521,11 +539,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739829690,
-        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "lastModified": 1743081648,
+        "narHash": "sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "rev": "29a3d7b768c70addce17af0869f6e2bd8f5be4b7",
         "type": "github"
       },
       "original": {

--- a/src/python/tools/nix/flake.lock
+++ b/src/python/tools/nix/flake.lock
@@ -336,11 +336,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1743093505,
-        "narHash": "sha256-JqrkanTUl369dn1GRU9bsyZJUq1epuR/CVsvUAt9aJw=",
+        "lastModified": 1743210254,
+        "narHash": "sha256-WSair8Op8eOoMX8DYCSdfSLLV4AGOaPmnyJQZ/qRBIs=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "a26a15d05c5ac198c369a830acc063c7524e04db",
+        "rev": "3f13cc0f8739a1a70e52326af9ec49cee536128a",
         "type": "github"
       },
       "original": {
@@ -436,11 +436,11 @@
     },
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1742937945,
-        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
+        "lastModified": 1743367904,
+        "narHash": "sha256-sOos1jZGKmT6xxPvxGQyPTApOunXvScV4lNjBCXd/CI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
+        "rev": "7ffe0edc685f14b8c635e3d6591b0bbb97365e6c",
         "type": "github"
       },
       "original": {
@@ -468,11 +468,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1742889210,
-        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
         "type": "github"
       },
       "original": {

--- a/src/python/tools/nix/flake.lock
+++ b/src/python/tools/nix/flake.lock
@@ -336,11 +336,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1743210254,
-        "narHash": "sha256-WSair8Op8eOoMX8DYCSdfSLLV4AGOaPmnyJQZ/qRBIs=",
+        "lastModified": 1743489973,
+        "narHash": "sha256-v3Wua1bv77s4gsWHrLZKWu09PqjSYoLIMAclF7ZpdeI=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "3f13cc0f8739a1a70e52326af9ec49cee536128a",
+        "rev": "6fe39566d2893e790c9ce8077d067f32b1b7b49a",
         "type": "github"
       },
       "original": {

--- a/src/python/tools/nix/shells/toolchain-python.nix
+++ b/src/python/tools/nix/shells/toolchain-python.nix
@@ -1,61 +1,58 @@
-# This function defines attrsets with packages
-# to be used in the different development shells
-# in this folder.
-
+# This function returns a list of `devenv` modules
+# which are passed to `mkShell`.
+#
 # Search for package at:
 # https://search.nixos.org/packages
 {
-  lib,
+  # These are `pkgs` from `input.nixpkgs`.
   pkgs,
+  lib,
   namespace,
   ...
 }:
 [
-  (
-    { ... }:
-    {
-      packages = [
-        pkgs.${namespace}.bootstrap
-        pkgs.${namespace}.treefmt
+  {
+    packages = [
+      pkgs.${namespace}.bootstrap
+      pkgs.${namespace}.treefmt
 
-        # Language Server.
-        pkgs.pyright
+      # Language Server.
+      pkgs.pyright
 
-        # Formatter and linter.
-        pkgs.ruff
+      # Formatter and linter.
+      pkgs.ruff
 
-        pkgs.stdenv.cc.cc.lib # fix: libstdc++ required by jupyter.
-        pkgs.libz # fix: for numpy/pandas import
-      ];
+      pkgs.stdenv.cc.cc.lib # fix: libstdc++ required by jupyter.
+      pkgs.libz # fix: for numpy/pandas import
+    ];
 
-      # We use `devenv` language support since, its
-      # pretty involved to setup a python environment.
-      languages.python = {
-        directory = lib.${namespace}.fs.root-dir;
+    # We use `devenv` language support since, its
+    # pretty involved to setup a python environment.
+    languages.python = {
+      directory = lib.${namespace}.fs.root-dir;
+      enable = true;
+      venv.enable = true;
+      uv = {
         enable = true;
-        venv.enable = true;
-        uv = {
+        package = pkgs.uv;
+        sync = {
           enable = true;
-          package = pkgs.uv;
-          sync = {
-            enable = true;
-            allExtras = true;
-          };
+          allExtras = true;
         };
       };
+    };
 
-      env = {
-        RUFF_CACHE_DIR = ".output/cache/ruff";
-      };
+    env = {
+      RUFF_CACHE_DIR = ".output/cache/ruff";
+    };
 
-      enterShell = ''
-        just setup
-      '';
+    enterShell = ''
+      just setup
+    '';
 
-      env.LD_LIBRARY_PATH = "${lib.makeLibraryPath [
-        pkgs.stdenv.cc.cc.lib
-        pkgs.libz
-      ]}";
-    }
-  )
+    env.LD_LIBRARY_PATH = "${lib.makeLibraryPath [
+      pkgs.stdenv.cc.cc.lib
+      pkgs.libz
+    ]}";
+  }
 ]

--- a/src/rust/tools/nix/flake.lock
+++ b/src/rust/tools/nix/flake.lock
@@ -464,11 +464,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743042789,
-        "narHash": "sha256-yPlxN0r3pQjUIwyX/qeWSTdpHjWy/AfmM0PK1bYkO18=",
+        "lastModified": 1743129211,
+        "narHash": "sha256-gE8t+U9miTwm2NYWS9dFY8H1/QB4ifaFDq1KdV9KEqo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b4d2dee9d16e7725b71969f28862ded3a94a7934",
+        "rev": "f93da1d26ba9963f34f94a6872b67a7939699543",
         "type": "github"
       },
       "original": {

--- a/src/rust/tools/nix/flake.lock
+++ b/src/rust/tools/nix/flake.lock
@@ -320,11 +320,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1743093505,
-        "narHash": "sha256-JqrkanTUl369dn1GRU9bsyZJUq1epuR/CVsvUAt9aJw=",
+        "lastModified": 1743210254,
+        "narHash": "sha256-WSair8Op8eOoMX8DYCSdfSLLV4AGOaPmnyJQZ/qRBIs=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "a26a15d05c5ac198c369a830acc063c7524e04db",
+        "rev": "3f13cc0f8739a1a70e52326af9ec49cee536128a",
         "type": "github"
       },
       "original": {
@@ -399,11 +399,11 @@
     },
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1742937945,
-        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
+        "lastModified": 1743367904,
+        "narHash": "sha256-sOos1jZGKmT6xxPvxGQyPTApOunXvScV4lNjBCXd/CI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
+        "rev": "7ffe0edc685f14b8c635e3d6591b0bbb97365e6c",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1742889210,
-        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
         "type": "github"
       },
       "original": {
@@ -464,11 +464,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743129211,
-        "narHash": "sha256-gE8t+U9miTwm2NYWS9dFY8H1/QB4ifaFDq1KdV9KEqo=",
+        "lastModified": 1743388531,
+        "narHash": "sha256-OBcNE+2/TD1AMgq8HKMotSQF8ZPJEFGZdRoBJ7t/HIc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f93da1d26ba9963f34f94a6872b67a7939699543",
+        "rev": "011de3c895927300651d9c2cb8e062adf17aa665",
         "type": "github"
       },
       "original": {

--- a/src/rust/tools/nix/flake.lock
+++ b/src/rust/tools/nix/flake.lock
@@ -320,11 +320,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1743210254,
-        "narHash": "sha256-WSair8Op8eOoMX8DYCSdfSLLV4AGOaPmnyJQZ/qRBIs=",
+        "lastModified": 1743489973,
+        "narHash": "sha256-v3Wua1bv77s4gsWHrLZKWu09PqjSYoLIMAclF7ZpdeI=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "3f13cc0f8739a1a70e52326af9ec49cee536128a",
+        "rev": "6fe39566d2893e790c9ce8077d067f32b1b7b49a",
         "type": "github"
       },
       "original": {
@@ -464,11 +464,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743388531,
-        "narHash": "sha256-OBcNE+2/TD1AMgq8HKMotSQF8ZPJEFGZdRoBJ7t/HIc=",
+        "lastModified": 1743475035,
+        "narHash": "sha256-uLjVsb4Rxnp1zmFdPCDmdODd4RY6ETOeRj0IkC0ij/4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "011de3c895927300651d9c2cb8e062adf17aa665",
+        "rev": "bee11c51c2cda3ac57c9e0149d94b86cc1b00d13",
         "type": "github"
       },
       "original": {

--- a/src/rust/tools/nix/flake.lock
+++ b/src/rust/tools/nix/flake.lock
@@ -468,15 +468,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1736130495,
-        "narHash": "sha256-4i9nAJEZFv7vZMmrE0YG55I3Ggrtfo5/T07JEpEZ/RM=",
+        "lastModified": 1718097323,
+        "narHash": "sha256-zCgs8Wp7rdt0tjNUHMUIvi6sIvDoprWIHwvTGq+LMK0=",
         "owner": "snowfallorg",
         "repo": "lib",
-        "rev": "02d941739f98a09e81f3d2d9b3ab08918958beac",
+        "rev": "aa19b02b63025263cec041fcb7a0857c3cb98859",
         "type": "github"
       },
       "original": {
         "owner": "snowfallorg",
+        "ref": "v3.0.3",
         "repo": "lib",
         "type": "github"
       }

--- a/src/rust/tools/nix/flake.lock
+++ b/src/rust/tools/nix/flake.lock
@@ -35,19 +35,20 @@
         "git-hooks": "git-hooks",
         "nix": "nix",
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgsDevenv"
         ]
       },
       "locked": {
-        "lastModified": 1742214310,
-        "narHash": "sha256-n5bdCsgv7+EtBH8R1rNEMPHskdHtTdm2tPHs0Hwle8s=",
+        "lastModified": 1739852725,
+        "narHash": "sha256-OjdnHKQ+eWA8YvPUpl3xxyaNK91c9sMebqXgVdN8Lm4=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "52db4dfc65cb0bc527dea0cc92aa475acf4e8f7f",
+        "rev": "98b99188b1539c0d2a45e0a0a161a7b8e797caac",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
+        "ref": "latest",
         "repo": "devenv",
         "type": "github"
       }
@@ -192,11 +193,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740849354,
-        "narHash": "sha256-oy33+t09FraucSZ2rZ6qnD1Y1c8azKKmQuCvF2ytUko=",
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4a709a8ce9f8c08fa7ddb86761fe488ff7858a07",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {
@@ -319,11 +320,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1742159602,
-        "narHash": "sha256-Fr3KNT1lMw6zWgm+oHp2wgFj9TLJXsRZHozk6vv/9Ow=",
+        "lastModified": 1743093505,
+        "narHash": "sha256-JqrkanTUl369dn1GRU9bsyZJUq1epuR/CVsvUAt9aJw=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "2cfd0315113edebefc38dd7f9d7dd57599629dc6",
+        "rev": "a26a15d05c5ac198c369a830acc063c7524e04db",
         "type": "github"
       },
       "original": {
@@ -380,13 +381,29 @@
         "type": "github"
       }
     },
+    "nixpkgsDevenv": {
+      "locked": {
+        "lastModified": 1733477122,
+        "narHash": "sha256-qamMCz5mNpQmgBwc8SB5tVMlD5sbwVIToVZtSxMph9s=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "7bd9e84d0452f6d2e63b6e6da29fe73fac951857",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1742136038,
-        "narHash": "sha256-DDe16FJk18sadknQKKG/9FbwEro7A57tg9vB5kxZ8kY=",
+        "lastModified": 1742937945,
+        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a1185f4064c18a5db37c5c84e5638c78b46e3341",
+        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
         "type": "github"
       },
       "original": {
@@ -414,11 +431,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1742069588,
-        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
+        "lastModified": 1742889210,
+        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
+        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
         "type": "github"
       },
       "original": {
@@ -433,6 +450,7 @@
         "devenv": "devenv",
         "nix": "nix_2",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgsDevenv": "nixpkgsDevenv",
         "nixpkgsStable": "nixpkgsStable",
         "rust-overlay": "rust-overlay",
         "snowfall-lib": "snowfall-lib",
@@ -446,11 +464,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742178793,
-        "narHash": "sha256-S2onMdoDS4tIYd3/Jc5oFEZBr2dJOgPrh9KzSO/bfDw=",
+        "lastModified": 1743042789,
+        "narHash": "sha256-yPlxN0r3pQjUIwyX/qeWSTdpHjWy/AfmM0PK1bYkO18=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "954582a766a50ebef5695a9616c93b5386418c08",
+        "rev": "b4d2dee9d16e7725b71969f28862ded3a94a7934",
         "type": "github"
       },
       "original": {
@@ -504,11 +522,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739829690,
-        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "lastModified": 1743081648,
+        "narHash": "sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "rev": "29a3d7b768c70addce17af0869f6e2bd8f5be4b7",
         "type": "github"
       },
       "original": {

--- a/src/rust/tools/nix/shells/toolchain-rust.nix
+++ b/src/rust/tools/nix/shells/toolchain-rust.nix
@@ -1,35 +1,32 @@
-# This function defines attrsets with packages
-# to be used in the different development shells
-# in this folder.
-
+# This function returns a list of `devenv` modules
+# which are passed to `mkShell`.
+#
 # Search for package at:
 # https://search.nixos.org/packages
 {
+  # These are `pkgs` from `input.nixpkgs`.
   pkgs,
   namespace,
   ...
 }:
 [
-  (
-    { ... }:
-    {
-      packages = [
-        pkgs.${namespace}.bootstrap
-        pkgs.${namespace}.treefmt
-        pkgs.${namespace}.rust-toolchain
-        pkgs.cargo-watch
+  {
+    packages = [
+      pkgs.${namespace}.bootstrap
+      pkgs.${namespace}.treefmt
+      pkgs.${namespace}.rust-toolchain
+      pkgs.cargo-watch
 
-        # Debugging
-        pkgs.lldb_18
-      ];
-      enterShell = ''
-        repo_dir=$(git rev-parse --show-toplevel)
-        # Set the default output directory.
-        export CARGO_TARGET_DIR="$repo_dir/build"
-        unset repo_dir
+      # Debugging
+      pkgs.lldb_18
+    ];
+    enterShell = ''
+      repo_dir=$(git rev-parse --show-toplevel)
+      # Set the default output directory.
+      export CARGO_TARGET_DIR="$repo_dir/build"
+      unset repo_dir
 
-        just setup
-      '';
-    }
-  )
+      just setup
+    '';
+  }
 ]

--- a/tools/just/maintenance.just
+++ b/tools/just/maintenance.just
@@ -41,7 +41,7 @@ test-all:
     just maintenance::test python
     just maintenance::test rust
     just maintenance::test go
-    just maintenance::test-images
+    just maintenance::test-image
 
 # Test the code scaffolding.
 test template="python": ci-setup setup

--- a/tools/just/maintenance.just
+++ b/tools/just/maintenance.just
@@ -79,7 +79,10 @@ test template="python": setup
         git commit -a -m "init"
 
     if [ "${REPOSITORY_TEMPLATE_UPDATE_FLAKES:-}" = "true" ]; then
-        ci::print_warn "Updating flakes in template."
+        ci::print_warn \
+        "===========================" \
+        "Updating flakes in template." \
+        "==========================="
         (cd tools/nix && nix flake update)
     fi
 

--- a/tools/just/maintenance.just
+++ b/tools/just/maintenance.just
@@ -44,7 +44,7 @@ test-all:
     just maintenance::test-images
 
 # Test the code scaffolding.
-test template="python": setup
+test template="python": ci-setup setup
     #!/usr/bin/env bash
     set -eu
     source "{{root_dir}}/tools/ci/general.sh"
@@ -109,7 +109,7 @@ test template="python": setup
     fi
 
 # Create and upload the code scaffolding.
-upload-all: setup
+upload-all:
     just maintenance::upload generic
     just maintenance::upload rust
     just maintenance::upload go
@@ -118,7 +118,7 @@ upload-all: setup
     just maintenance::push-deploy-image
 
 # Create and upload the code scaffolding.
-upload template="python": setup
+upload template="python": ci-setup setup
     #!/usr/bin/env bash
     set -eu
     source "{{root_dir}}/tools/ci/general.sh"
@@ -177,3 +177,10 @@ test-image:
     "{{container_mgr}}" run -it -v "{{output_dir}}/image:/workspace" \
             ghcr.io/sdsc-ordes/repository-template:latest \
             -t python -d "./test" -- -w -l
+
+[private]
+ci-setup:
+    #!/usr/bin/env bash
+    [ "${CI:-}" == true ] || exit 0
+    git config --global user.name "CI"
+    git config --global user.email "ci@noreply.github.com"

--- a/tools/nix/flake.lock
+++ b/tools/nix/flake.lock
@@ -431,11 +431,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1742069588,
-        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
         "type": "github"
       },
       "original": {

--- a/tools/nix/flake.lock
+++ b/tools/nix/flake.lock
@@ -39,15 +39,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1742147141,
-        "narHash": "sha256-pTgorBdmI0rMrFirATgMIye65/jL72De8Kxh7rBT/58=",
+        "lastModified": 1739852725,
+        "narHash": "sha256-OjdnHKQ+eWA8YvPUpl3xxyaNK91c9sMebqXgVdN8Lm4=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "e1eb23d427a3a0871c277268a28163898fd37266",
+        "rev": "98b99188b1539c0d2a45e0a0a161a7b8e797caac",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
+        "ref": "latest",
         "repo": "devenv",
         "type": "github"
       }
@@ -447,15 +448,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1736130495,
-        "narHash": "sha256-4i9nAJEZFv7vZMmrE0YG55I3Ggrtfo5/T07JEpEZ/RM=",
+        "lastModified": 1718097323,
+        "narHash": "sha256-zCgs8Wp7rdt0tjNUHMUIvi6sIvDoprWIHwvTGq+LMK0=",
         "owner": "snowfallorg",
         "repo": "lib",
-        "rev": "02d941739f98a09e81f3d2d9b3ab08918958beac",
+        "rev": "aa19b02b63025263cec041fcb7a0857c3cb98859",
         "type": "github"
       },
       "original": {
         "owner": "snowfallorg",
+        "ref": "v3.0.3",
         "repo": "lib",
         "type": "github"
       }

--- a/tools/nix/flake.lock
+++ b/tools/nix/flake.lock
@@ -35,7 +35,7 @@
         "git-hooks": "git-hooks",
         "nix": "nix",
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgsDevenv"
         ]
       },
       "locked": {
@@ -381,6 +381,22 @@
         "type": "github"
       }
     },
+    "nixpkgsDevenv": {
+      "locked": {
+        "lastModified": 1733477122,
+        "narHash": "sha256-qamMCz5mNpQmgBwc8SB5tVMlD5sbwVIToVZtSxMph9s=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "7bd9e84d0452f6d2e63b6e6da29fe73fac951857",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgsStable": {
       "locked": {
         "lastModified": 1742136038,
@@ -434,6 +450,7 @@
         "devenv": "devenv",
         "nix": "nix_2",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgsDevenv": "nixpkgsDevenv",
         "nixpkgsStable": "nixpkgsStable",
         "snowfall-lib": "snowfall-lib",
         "treefmt-nix": "treefmt-nix"

--- a/tools/nix/flake.nix
+++ b/tools/nix/flake.nix
@@ -23,8 +23,12 @@
     # The devenv module to create good development shells.
     devenv = {
       url = "github:cachix/devenv/latest";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs.follows = "nixpkgsDevenv";
     };
+    # We have to lock somehow the pkgs in `mkShell` here:
+    # https://github.com/cachix/devenv/issues/1797
+    # `nixpkgs` is used in the devShell modules.
+    nixpkgsDevenv.url = "github:cachix/devenv-nixpkgs/rolling";
 
     # Format the repo with nix-treefmt.
     treefmt-nix = {

--- a/tools/nix/flake.nix
+++ b/tools/nix/flake.nix
@@ -2,12 +2,14 @@
   description = "repository-template";
 
   nixConfig = {
-    extra-substituters = [
+    extra-trusted-substituters = [
       # Nix community's cache server
       "https://nix-community.cachix.org"
+      "https://devenv.cachix.org"
     ];
     extra-trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
     ];
   };
 
@@ -20,7 +22,7 @@
 
     # The devenv module to create good development shells.
     devenv = {
-      url = "github:cachix/devenv";
+      url = "github:cachix/devenv/latest";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -39,7 +41,7 @@
     # Snowfall provides a structured way of creating a flake output.
     # Documentation: https://snowfall.org/guides/lib/quickstart/
     snowfall-lib = {
-      url = "github:snowfallorg/lib";
+      url = "github:snowfallorg/lib?ref=v3.0.3";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/tools/nix/flake.nix
+++ b/tools/nix/flake.nix
@@ -56,7 +56,9 @@
       root-dir = ../..;
     in
     inputs.snowfall-lib.mkFlake {
-      inherit inputs;
+      inputs = inputs // {
+        self = inputs.self;
+      };
 
       # The `src` must be the root of the flake.
       src = "${root-dir}";

--- a/tools/nix/shells/ci/default.nix
+++ b/tools/nix/shells/ci/default.nix
@@ -8,6 +8,7 @@ let
   toolchains = import ../toolchain.nix { inherit pkgs namespace inputs; };
 in
 inputs.devenv.lib.mkShell {
-  inherit pkgs inputs;
+  inherit inputs;
+  pkgs = inputs.nixpkgsDevenv.legacyPackages.${pkgs.system};
   modules = toolchains.ci;
 }

--- a/tools/nix/shells/ci/default.nix
+++ b/tools/nix/shells/ci/default.nix
@@ -1,5 +1,6 @@
 {
   inputs,
+  lib,
   namespace,
   pkgs,
   ...
@@ -7,8 +8,8 @@
 let
   toolchains = import ../toolchain.nix { inherit pkgs namespace inputs; };
 in
-inputs.devenv.lib.mkShell {
+lib.${namespace}.makeShell {
   inherit inputs;
-  pkgs = inputs.nixpkgsDevenv.legacyPackages.${pkgs.system};
+  inherit (pkgs) system;
   modules = toolchains.ci;
 }

--- a/tools/nix/shells/default/default.nix
+++ b/tools/nix/shells/default/default.nix
@@ -1,5 +1,6 @@
 {
   inputs,
+  lib,
   namespace,
   pkgs,
   ...
@@ -7,8 +8,8 @@
 let
   toolchains = import ../toolchain.nix { inherit pkgs namespace inputs; };
 in
-inputs.devenv.lib.mkShell {
+lib.${namespace}.makeShell {
   inherit inputs;
-  pkgs = inputs.nixpkgsDevenv.legacyPackages.${pkgs.system};
+  inherit (pkgs) system;
   modules = toolchains.default;
 }

--- a/tools/nix/shells/default/default.nix
+++ b/tools/nix/shells/default/default.nix
@@ -8,6 +8,7 @@ let
   toolchains = import ../toolchain.nix { inherit pkgs namespace inputs; };
 in
 inputs.devenv.lib.mkShell {
-  inherit pkgs inputs;
+  inherit inputs;
+  pkgs = inputs.nixpkgsDevenv.legacyPackages.${pkgs.system};
   modules = toolchains.default;
 }

--- a/tools/nix/shells/format/default.nix
+++ b/tools/nix/shells/format/default.nix
@@ -5,7 +5,8 @@
   ...
 }:
 inputs.devenv.lib.mkShell {
-  inherit pkgs inputs;
+  inherit inputs;
+  pkgs = inputs.nixpkgsDevenv.legacyPackages.${pkgs.system};
   modules = [
     (
       { ... }:

--- a/tools/nix/shells/format/default.nix
+++ b/tools/nix/shells/format/default.nix
@@ -1,20 +1,18 @@
 {
+  inputs,
+  lib,
   pkgs,
   namespace,
-  inputs,
   ...
 }:
-inputs.devenv.lib.mkShell {
+lib.${namespace}.makeShell {
   inherit inputs;
-  pkgs = inputs.nixpkgsDevenv.legacyPackages.${pkgs.system};
+  inherit (pkgs) system;
   modules = [
-    (
-      { ... }:
-      {
-        packages = [
-          pkgs.${namespace}.treefmt
-        ];
-      }
-    )
+    (args: {
+      packages = [
+        pkgs.${namespace}.treefmt
+      ];
+    })
   ];
 }

--- a/tools/nix/shells/format/default.nix
+++ b/tools/nix/shells/format/default.nix
@@ -9,10 +9,10 @@ lib.${namespace}.makeShell {
   inherit inputs;
   inherit (pkgs) system;
   modules = [
-    (args: {
+    {
       packages = [
         pkgs.${namespace}.treefmt
       ];
-    })
+    }
   ];
 }

--- a/tools/nix/shells/toolchain.nix
+++ b/tools/nix/shells/toolchain.nix
@@ -12,32 +12,29 @@
 let
   # Packages for the 'default' shell.
   default = [
-    (
-      { ... }:
-      {
-        packages = with pkgs; [
-          # Stuff you always want ==============================
-          pkgs.${namespace}.bootstrap
-          pkgs.${namespace}.treefmt
-          # ====================================================
+    {
+      packages = with pkgs; [
+        # Stuff you always want ==============================
+        pkgs.${namespace}.bootstrap
+        pkgs.${namespace}.treefmt
+        # ====================================================
 
-          skopeo
+        skopeo
 
-          uv
-          python313
-          yq
-        ];
+        uv
+        python313
+        yq
+      ];
 
-        env = {
-          RUFF_CACHE_DIR = ".output/cache/ruff";
-        };
+      env = {
+        RUFF_CACHE_DIR = ".output/cache/ruff";
+      };
 
-        enterShell = ''
-          just setup
-          source ./tools/scripts/activate-env.sh
-        '';
-      }
-    )
+      enterShell = ''
+        just setup
+        source ./tools/scripts/activate-env.sh
+      '';
+    }
   ];
 
   # Packages for the 'ci' shell.


### PR DESCRIPTION
## Proposed Changes

- This changes introduces a function in `lib` to create a `mkShell`. It locks the `input.devenv.lib.mkShell` `pkgs` input to 
  `devenvNixpkgs` which is `github:cachix/devenv-nixpkgs/rolling`.
- I wait in this PR for https://nixpk.gs/pr-tracker.html?pr=393626 until then `golangci-lint-langserver` does not build yet.
- All templates are adjusted to pin `snowfall` and `devevn` input to a version.

## Types of Changes

What types of changes does your contribution introduce? _Put an `x` in the boxes
that apply_

- [x] A **bug fix** (non-breaking change which fixes an issue). Use MR tag
      `bugfix`.
- [x] A new **feature** (non-breaking change which adds functionality). Use MR
      tag `feature`.
- [ ] A **breaking change** (fix or feature that would cause existing
      functionality to not work as expected). Use MR tag `feature`.
- [ ] A **non-productive** update (documentation, tooling, etc. if none of the
      other choices apply). Use MR tag `chore`.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] I have read the
      [CONTRIBUTING](https://github.com/sdsc-ordes/repository-template/tree/main/CONTRIBUTING.md)
      guidelines.

## Further Comments

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->
